### PR TITLE
Add spin wheel UI with admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ npm start
 npm run gen -- "Write a Python function that checks if a string is a palindrome."
 ```
 
+## Spin Wheel UI
+
+Static pages for a 10‑segment spin wheel and admin panel live in `public/`.
+
+- Open `public/index.html` to view and spin the wheel.
+- Use the “Go to Admin Panel” button to edit segment labels (stored in `localStorage`).
+
 ## Files
 ```
 codex-project/

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Admin Panel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <form id="segments-form"></form>
+  <button id="save">Save Segments</button>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,19 @@
+const form = document.getElementById('segments-form');
+const stored = JSON.parse(localStorage.getItem('segments')) || Array.from({ length: 10 }, (_, i) => `Segment ${i + 1}`);
+
+stored.forEach((seg, idx) => {
+  const label = document.createElement('label');
+  label.textContent = `Segment ${idx + 1}`;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.value = seg;
+  label.appendChild(input);
+  form.appendChild(label);
+});
+
+document.getElementById('save').addEventListener('click', () => {
+  const inputs = form.querySelectorAll('input');
+  const segments = Array.from(inputs).map((el, i) => el.value || `Segment ${i + 1}`);
+  localStorage.setItem('segments', JSON.stringify(segments));
+  alert('Segments saved!');
+});

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Spin the Wheel</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <a href="admin.html" class="admin-link">Go to Admin Panel</a>
+  <canvas id="wheel" width="400" height="400"></canvas>
+  <button id="spin">Spin</button>
+  <script src="wheel.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,49 @@
+body {
+  margin: 0;
+  background: #800080;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  color: #000;
+  font-family: sans-serif;
+}
+.admin-link {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: #fff;
+  color: #800080;
+  padding: 8px 12px;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+}
+#wheel {
+  width: 400px;
+  height: 400px;
+}
+#spin {
+  margin-top: 20px;
+  padding: 10px 20px;
+  font-size: 16px;
+}
+#segments-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+#segments-form label {
+  display: flex;
+  flex-direction: column;
+  color: #fff;
+}
+#segments-form input {
+  padding: 4px;
+}
+#save {
+  margin-top: 12px;
+  padding: 8px 12px;
+  font-size: 16px;
+}

--- a/public/wheel.js
+++ b/public/wheel.js
@@ -1,0 +1,46 @@
+const canvas = document.getElementById('wheel');
+const ctx = canvas.getContext('2d');
+const size = canvas.width;
+const center = size / 2;
+const radius = center;
+
+const defaultSegments = Array.from({ length: 10 }, (_, i) => `Segment ${i + 1}`);
+let segments = JSON.parse(localStorage.getItem('segments')) || defaultSegments;
+
+const colors = ['#f3e5f5', '#ffffff'];
+
+function drawWheel() {
+  const angle = (2 * Math.PI) / segments.length;
+  segments.forEach((seg, i) => {
+    const start = i * angle;
+    const end = start + angle;
+    ctx.beginPath();
+    ctx.moveTo(center, center);
+    ctx.arc(center, center, radius, start, end);
+    ctx.closePath();
+    ctx.fillStyle = colors[i % 2];
+    ctx.fill();
+
+    ctx.save();
+    ctx.translate(center, center);
+    ctx.rotate(start + angle / 2);
+    ctx.textAlign = 'right';
+    ctx.fillStyle = '#000';
+    ctx.font = '16px sans-serif';
+    ctx.fillText(seg, radius - 10, 5);
+    ctx.restore();
+  });
+}
+
+drawWheel();
+
+const spinBtn = document.getElementById('spin');
+spinBtn.addEventListener('click', () => {
+  const deg = 3600 + Math.random() * 360;
+  canvas.style.transition = 'transform 4s ease-out';
+  canvas.style.transform = `rotate(${deg}deg)`;
+  canvas.addEventListener('transitionend', () => {
+    canvas.style.transition = 'none';
+    canvas.style.transform = `rotate(${deg % 360}deg)`;
+  }, { once: true });
+});


### PR DESCRIPTION
## Summary
- Add static spin wheel page with 10 segments and link to admin panel
- Implement admin panel to edit segment labels stored in localStorage
- Document spin wheel usage in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b867ec6dac832e94a6a8c4233e6303