### PR TITLE
Fix spin button and leaderboard functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -214,8 +214,8 @@ button:focus {
     <div class="hub">Bolt Logo</div>
   </div>
 
-  <button id="spin" disabled>Spin</button>
-  <div id="result" aria-live="polite">You won: 10000 Pts!</div>
+  <button id="spin">Spin</button>
+  <div id="result" aria-live="polite">Spin to win points!</div>
   <button id="leaderboardBtn">Show Leaderboard</button>
 </div>
 
@@ -223,13 +223,7 @@ button:focus {
   <div class="modal">
     <button class="close-btn" aria-label="Close dialog">✕</button>
     <h2 id="leaderboardTitle">Leaderboard</h2>
-    <ol>
-      <li>Alice – 15000</li>
-      <li>Bob – 12000</li>
-      <li>Charlie – 11000</li>
-      <li>Denise – 9000</li>
-      <li>Eve – 5000</li>
-    </ol>
+    <ol id="leaderboardList"></ol>
   </div>
 </div>
 
@@ -281,6 +275,7 @@ function drawWheel() {
 
 drawWheel();
 
+// --- Spin logic ---
 function generateUserId() {
   let id = '';
   for (let i = 0; i < 16; i++) {
@@ -288,16 +283,65 @@ function generateUserId() {
   }
   return id;
 }
-document.getElementById('user-id').textContent = 'User ID: ' + generateUserId();
 
+const userId = generateUserId();
+document.getElementById('user-id').textContent = 'User ID: ' + userId;
+
+const canvas = document.getElementById('wheel');
+const spinBtn = document.getElementById('spin');
+const resultEl = document.getElementById('result');
+
+spinBtn.addEventListener('click', () => {
+  spinBtn.disabled = true;
+  const step = 360 / segments.length;
+  const index = Math.floor(Math.random() * segments.length);
+  const deg = 3600 + index * step + step / 2;
+  canvas.style.transition = 'transform 4s ease-out';
+  canvas.style.transform = `rotate(${deg}deg)`;
+  canvas.addEventListener('transitionend', async () => {
+    canvas.style.transition = 'none';
+    canvas.style.transform = `rotate(${deg % 360}deg)`;
+    const seg = segments[index];
+    resultEl.textContent = `You won: ${seg.label}`;
+    try {
+      await fetch('/api/logs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, rewardType: seg.label })
+      });
+    } catch (err) {
+      console.error(err);
+    }
+    spinBtn.disabled = false;
+  }, { once: true });
+});
+
+// --- Leaderboard modal ---
 const overlay = document.getElementById('overlay');
 const leaderboardBtn = document.getElementById('leaderboardBtn');
 const closeBtn = document.querySelector('.close-btn');
+
+async function loadLeaderboard() {
+  try {
+    const res = await fetch('/api/leaderboard');
+    const board = await res.json();
+    const list = document.getElementById('leaderboardList');
+    list.innerHTML = '';
+    board.forEach(row => {
+      const li = document.createElement('li');
+      li.textContent = `${row.userId} – ${row.points}`;
+      list.appendChild(li);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
 
 function openModal() {
   overlay.classList.add('active');
   overlay.addEventListener('click', outsideClick);
   document.addEventListener('keydown', escClose);
+  loadLeaderboard();
 }
 
 function closeModal() {


### PR DESCRIPTION
## Summary
- Enable spin button and log spins to backend API.
- Fetch and display dynamic leaderboard in modal.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run server` *(fails: Cannot find package 'express')*
- `npm install` *(fails: 403 Forbidden retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b871dfcd24832eb6d644fd2887ad77