### PR TITLE
Add flip animation leaderboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,14 +17,40 @@ body {
   color: #fff;
 }
 
-.card {
+.scene {
+  width: 90%;
+  max-width: 420px;
+  perspective: 1000px;
+}
+
+#card {
+  width: 100%;
+  height: 560px;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: transform 0.8s;
+}
+
+#card.flipped {
+  transform: rotateY(180deg);
+}
+
+.face {
   background: #1b1b3a;
   border-radius: 16px;
   padding: 24px;
   box-shadow: 0 8px 24px rgba(0,0,0,0.5);
   text-align: center;
-  width: 90%;
-  max-width: 420px;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  backface-visibility: hidden;
+}
+
+.face.back {
+  transform: rotateY(180deg);
 }
 
 h1 {
@@ -161,79 +187,60 @@ button:focus {
   background: #3498db;
 }
 
-/* modal */
-#overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
+/* leaderboard table */
+#board {
   width: 100%;
-  height: 100%;
-  background: rgba(0,0,0,0.6);
-  display: none;
-  align-items: center;
-  justify-content: center;
+  border-collapse: collapse;
+  margin-top: 16px;
 }
 
-#overlay.active {
-  display: flex;
+#board th, #board td {
+  border-bottom: 1px solid #333;
+  padding: 8px;
 }
 
-.modal {
-  background: #1b1b3a;
-  padding: 20px;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 300px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.5);
-  position: relative;
-  color: #fff;
+#board th {
+  text-align: left;
 }
 
-.modal h2 {
-  text-align: center;
-  margin-top: 0;
+#backBtn {
+  margin-top: 16px;
+  background: #e74c3c;
 }
 
-.close-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 1.2rem;
-  cursor: pointer;
-}
-
-.close-btn:hover {
-  color: #ddd;
+#backBtn:hover {
+  background: #c0392b;
 }
 </style>
 </head>
 <body>
-<div class="card">
-  <h1>LUCKY WHEEL</h1>
-  <p class="subtitle">Spin the wheel to win a prize!</p>
-  <p id="user-id">User ID:</p>
+<div class="scene">
+  <div id="card">
+    <div class="face front">
+      <h1>LUCKY WHEEL</h1>
+      <p class="subtitle">Spin the wheel to win a prize!</p>
+      <p id="user-id">User ID:</p>
 
-  <div id="wheel-wrapper">
-    <div class="axle"></div>
-    <canvas id="wheel" width="300" height="300"></canvas>
-    <div class="pointer"></div>
-    <div class="hub">Bolt Logo</div>
-  </div>
+      <div id="wheel-wrapper">
+        <div class="axle"></div>
+        <canvas id="wheel" width="300" height="300"></canvas>
+        <div class="pointer"></div>
+        <div class="hub">Bolt Logo</div>
+      </div>
 
-  <button id="spin">Spin</button>
-  <div id="result" aria-live="polite">Spin to win points!</div>
-  <button id="leaderboardBtn">Show Leaderboard</button>
-  <button id="adminBtn">Admin Panel</button>
-</div>
-
-<div id="overlay" role="dialog" aria-modal="true" aria-labelledby="leaderboardTitle">
-  <div class="modal">
-    <button class="close-btn" aria-label="Close dialog">✕</button>
-    <h2 id="leaderboardTitle">Leaderboard</h2>
-    <ol id="leaderboardList"></ol>
+      <button id="spin">Spin</button>
+      <div id="result" aria-live="polite">Spin to win points!</div>
+      <button id="leaderboardBtn">Show Leaderboard</button>
+      <button id="adminBtn">Admin Panel</button>
+    </div>
+    <div class="face back">
+      <h2>Leaderboard</h2>
+      <table id="board">
+        <thead><tr><th>User</th><th>Points</th></tr></thead>
+        <tbody></tbody>
+      </table>
+      <button id="backBtn">Back</button>
+    </div>
   </div>
 </div>
 
@@ -339,27 +346,26 @@ spinBtn.addEventListener('click', () => {
     spinBtn.disabled = false;
   }, { once: true });
 });
-
-// --- Leaderboard modal ---
-const overlay = document.getElementById('overlay');
+// --- Leaderboard flip ---
+const cardEl = document.getElementById('card');
 const leaderboardBtn = document.getElementById('leaderboardBtn');
-const closeBtn = document.querySelector('.close-btn');
+const backBtn = document.getElementById('backBtn');
+const tbody = document.querySelector('#board tbody');
 
 async function loadLeaderboard() {
   try {
     const res = await fetch('/api/leaderboard');
     const board = await res.json();
-    const list = document.getElementById('leaderboardList');
-    list.innerHTML = '';
+    tbody.innerHTML = '';
     if (board.length === 0) {
-      const li = document.createElement('li');
-      li.textContent = 'No entries yet';
-      list.appendChild(li);
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td colspan="2">No entries yet</td>';
+      tbody.appendChild(tr);
     } else {
       board.forEach(row => {
-        const li = document.createElement('li');
-        li.textContent = `${row.userId} – ${row.points}`;
-        list.appendChild(li);
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${row.userId}</td><td>${row.points}</td>`;
+        tbody.appendChild(tr);
       });
     }
   } catch (err) {
@@ -367,33 +373,17 @@ async function loadLeaderboard() {
   }
 }
 
-function openModal() {
-  overlay.classList.add('active');
-  overlay.addEventListener('click', outsideClick);
-  document.addEventListener('keydown', escClose);
+function showLeaderboard() {
   loadLeaderboard();
+  cardEl.classList.add('flipped');
 }
 
-function closeModal() {
-  overlay.classList.remove('active');
-  overlay.removeEventListener('click', outsideClick);
-  document.removeEventListener('keydown', escClose);
+function showWheel() {
+  cardEl.classList.remove('flipped');
 }
 
-function outsideClick(e) {
-  if (e.target === overlay) {
-    closeModal();
-  }
-}
-
-function escClose(e) {
-  if (e.key === 'Escape') {
-    closeModal();
-  }
-}
-
-leaderboardBtn.addEventListener('click', openModal);
-closeBtn.addEventListener('click', closeModal);
+leaderboardBtn.addEventListener('click', showLeaderboard);
+backBtn.addEventListener('click', showWheel);
 const adminBtn = document.getElementById('adminBtn');
 adminBtn.addEventListener('click', () => {
   window.location.href = 'admin.html';


### PR DESCRIPTION
## Summary
- Flip the wheel screen to reveal a leaderboard
- Show top 10 players in a table with back navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b90767a2ac832ebf456d6b58b2975f