### PR TITLE
feat: allow center logo upload

### DIFF
--- a/data/config.json
+++ b/data/config.json
@@ -1,6 +1,7 @@
 {
   "enabled": true,
   "resetTime": "00:00",
+  "logo": "",
   "rewardSegments": [
     {"label": "10 points", "value": 10, "probability": 0.5, "dailyCap": 100},
     {"label": "20 points", "value": 20, "probability": 0.3, "dailyCap": 50},

--- a/public/admin.html
+++ b/public/admin.html
@@ -10,6 +10,10 @@
   <label><input type="checkbox" id="enabled" /> Enable Daily Spin</label>
   <label>Reset Time: <input type="time" id="resetTime" value="00:00" /></label>
 
+  <h2>Logo</h2>
+  <input type="file" id="logoInput" accept="image/png, image/jpeg" />
+  <img id="logoPreview" alt="Logo preview" style="max-width:100px; display:none;" />
+
   <h2>Reward Segments</h2>
   <table id="segments-table">
     <thead>

--- a/public/admin.js
+++ b/public/admin.js
@@ -2,6 +2,9 @@ const enabledEl = document.getElementById('enabled');
 const resetEl = document.getElementById('resetTime');
 const segTable = document.getElementById('segments-table').querySelector('tbody');
 const logsTable = document.getElementById('logs-table').querySelector('tbody');
+const logoInput = document.getElementById('logoInput');
+const logoPreview = document.getElementById('logoPreview');
+let logoData = '';
 
 function addRow(seg = {}) {
   const tr = document.createElement('tr');
@@ -18,6 +21,11 @@ async function loadConfig() {
   const cfg = await res.json();
   enabledEl.checked = cfg.enabled;
   resetEl.value = cfg.resetTime;
+  logoData = cfg.logo || '';
+  if (logoData) {
+    logoPreview.src = logoData;
+    logoPreview.style.display = 'block';
+  }
   segTable.innerHTML = '';
   (cfg.rewardSegments || []).forEach(s => addRow(s));
 }
@@ -35,6 +43,18 @@ async function loadLogs() {
 
 document.getElementById('add-segment').addEventListener('click', () => addRow());
 
+logoInput.addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    logoData = ev.target.result;
+    logoPreview.src = logoData;
+    logoPreview.style.display = 'block';
+  };
+  reader.readAsDataURL(file);
+});
+
 document.getElementById('save-config').addEventListener('click', async () => {
   const rows = Array.from(segTable.querySelectorAll('tr'));
   const rewardSegments = rows.map(r => {
@@ -49,7 +69,8 @@ document.getElementById('save-config').addEventListener('click', async () => {
   const body = {
     enabled: enabledEl.checked,
     resetTime: resetEl.value,
-    rewardSegments
+    rewardSegments,
+    logo: logoData
   };
   await fetch('/api/config', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
   alert('Config saved');

--- a/public/index.html
+++ b/public/index.html
@@ -123,6 +123,12 @@ h1 {
   box-shadow: 0 0 6px rgba(0,0,0,0.6) inset;
 }
 
+.hub img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
 .axle {
   position: absolute;
   top: 50%;
@@ -225,7 +231,7 @@ button:focus {
         <div class="axle"></div>
         <canvas id="wheel" width="300" height="300"></canvas>
         <div class="pointer"></div>
-        <div class="hub">Bolt Logo</div>
+        <div class="hub"><img id="hub-logo" alt="Logo" /></div>
       </div>
 
       <button id="spin">Spin</button>

--- a/public/wheel.js
+++ b/public/wheel.js
@@ -13,6 +13,12 @@ async function loadConfig() {
   const res = await fetch('/api/config');
   config = await res.json();
   segments = config.rewardSegments.map(s => s.label);
+  const logoImg = document.getElementById('hub-logo');
+  if (config.logo) {
+    logoImg.src = config.logo;
+  } else {
+    logoImg.style.display = 'none';
+  }
   drawWheel();
 }
 


### PR DESCRIPTION
## Summary
- add logo upload and preview to admin panel
- store uploaded logo in config and render in wheel center
- style hub to fit logo image

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b909c92da4832e9fce7c627b3f88b1