### PR TITLE
Fix logo display and leaderboard navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -217,6 +217,12 @@ button:focus {
 #backBtn:hover {
   background: #c0392b;
 }
+#card.flipped .front {
+  pointer-events: none;
+}
+#card:not(.flipped) .back {
+  pointer-events: none;
+}
 </style>
 </head>
 <body>
@@ -260,6 +266,13 @@ async function loadConfig() {
     const res = await fetch('/api/config');
     config = await res.json();
     segments = config.rewardSegments.map((s, i) => ({ label: s.label, color: colors[i % colors.length] }));
+    const logoImg = document.getElementById('hub-logo');
+    if (config.logo) {
+      logoImg.src = config.logo;
+      logoImg.style.display = 'block';
+    } else {
+      logoImg.style.display = 'none';
+    }
     drawWheel();
   } catch (err) {
     console.error('Failed to load config', err);


### PR DESCRIPTION
## Summary
- Display uploaded logo on the wheel by applying configuration logo to hub image
- Enable leaderboard back button by disabling pointer events on hidden card face

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b90bc0cb4c832eb983e54ee882941e