### PR TITLE
Allow larger JSON payload for logo

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,8 @@ function writeJSON(p, data) {
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// Allow larger JSON bodies so base64-encoded logos can be saved
+app.use(express.json({ limit: '5mb' }));
 app.use(express.static(path.join(__dirname, '../public')));
 
 // Config endpoints


### PR DESCRIPTION
## Summary
- allow larger JSON bodies so base64-encoded logo uploads succeed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b91290d874832eaefebb167e10c30d