### PR TITLE
feat: make UI responsive for wheel and admin

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -2,35 +2,42 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin Panel</title>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
-  <h1>Admin Panel</h1>
-  <label><input type="checkbox" id="enabled" /> Enable Daily Spin</label>
-  <label>Reset Time: <input type="time" id="resetTime" value="00:00" /></label>
+<body class="admin-page">
+  <div class="admin-container">
+    <h1>Admin Panel</h1>
+    <label><input type="checkbox" id="enabled" /> Enable Daily Spin</label>
+    <label>Reset Time: <input type="time" id="resetTime" value="00:00" /></label>
 
-  <h2>Logo</h2>
-  <input type="file" id="logoInput" accept="image/png, image/jpeg" />
-  <img id="logoPreview" alt="Logo preview" style="max-width:100px; display:none;" />
+    <h2>Logo</h2>
+    <input type="file" id="logoInput" accept="image/png, image/jpeg" />
+    <img id="logoPreview" alt="Logo preview" style="max-width:100px; display:none;" />
 
-  <h2>Reward Segments</h2>
-  <table id="segments-table">
-    <thead>
-      <tr><th>Label</th><th>Value</th><th>Probability</th><th>Daily Cap</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-  <button id="add-segment">Add Segment</button>
-  <button id="save-config">Save Config</button>
+    <h2>Reward Segments</h2>
+    <div class="table-wrapper">
+      <table id="segments-table">
+        <thead>
+          <tr><th>Label</th><th>Value</th><th>Probability</th><th>Daily Cap</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <button id="add-segment">Add Segment</button>
+    <button id="save-config">Save Config</button>
 
-  <h2>Activity Logs</h2>
-  <table id="logs-table">
-    <thead><tr><th>User</th><th>Reward</th><th>Time</th></tr></thead>
-    <tbody></tbody>
-  </table>
-  <a href="/api/reports/export?type=reward" target="_blank">Export Reward CSV</a>
-  <a href="/api/reports/export?type=summary" target="_blank">Export Summary CSV</a>
+    <h2>Activity Logs</h2>
+    <div class="table-wrapper">
+      <table id="logs-table">
+        <thead><tr><th>User</th><th>Reward</th><th>Time</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <a href="/api/reports/export?type=reward" target="_blank">Export Reward CSV</a>
+    <a href="/api/reports/export?type=summary" target="_blank">Export Summary CSV</a>
+  </div>
 
   <script src="admin.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Lucky Wheel</title>
 <style>
 * { box-sizing: border-box; }
@@ -25,7 +26,7 @@ body {
 
 #card {
   width: 100%;
-  height: 560px;
+  height: clamp(520px, 80vh, 560px);
   position: relative;
   transform-style: preserve-3d;
   transition: transform 0.8s;
@@ -55,7 +56,7 @@ body {
 
 h1 {
   margin: 0;
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 6vw, 2rem);
   font-weight: 700;
   background: linear-gradient(45deg,#ff7a00,#ffe600);
   -webkit-background-clip: text;
@@ -110,15 +111,15 @@ h1 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 70px;
-  height: 70px;
+  width: clamp(50px, 15vw, 70px);
+  height: clamp(50px, 15vw, 70px);
   background: #fff;
   color: #000;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.8rem;
+  font-size: clamp(0.7rem, 2vw, 0.8rem);
   z-index: 2;
   box-shadow: 0 0 6px rgba(0,0,0,0.6) inset;
 }
@@ -222,6 +223,12 @@ button:focus {
 }
 #card:not(.flipped) .back {
   pointer-events: none;
+}
+
+@media (max-width: 480px) {
+  .face {
+    padding: 16px;
+  }
 }
 </style>
 </head>

--- a/public/style.css
+++ b/public/style.css
@@ -5,9 +5,15 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  min-height: 100vh;
   color: #fff;
   font-family: sans-serif;
+}
+
+body.admin-page {
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 20px;
 }
 .admin-link {
   position: absolute;
@@ -22,8 +28,8 @@ body {
 }
 #wheel-container {
   position: relative;
-  width: 400px;
-  height: 400px;
+  width: min(90vw, 400px);
+  height: min(90vw, 400px);
 }
 
 #pointer {
@@ -83,10 +89,22 @@ body {
 table {
   border-collapse: collapse;
   margin-bottom: 12px;
+  width: 100%;
 }
 
 th, td {
   border: 1px solid #fff;
   padding: 4px 8px;
   color: #fff;
+}
+
+.admin-container {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
 }


### PR DESCRIPTION
## Summary
- make spin wheel page adapt to mobile devices using viewport meta, flexible sizing, and media queries
- wrap admin panel content in a responsive container and add horizontal scrolling for wide tables
- add responsive stylesheet rules for wheel canvas and admin layout

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9143e7d94832e8fb11ee03cdf7111