### PR TITLE
feat: prompt for player name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -283,7 +283,7 @@ button:focus {
     <div class="face front">
       <h1>LUCKY WHEEL</h1>
       <p class="subtitle">Spin the wheel to win a prize!</p>
-      <p id="user-id">User ID:</p>
+      <p id="user-id">User:</p>
 
       <div id="wheel-wrapper">
         <div class="axle"></div>
@@ -320,6 +320,22 @@ button:focus {
 let config;
 let segments = [];
 const colors = ["#ff9f1c", "#e71d36", "#2ec4b6", "#3a86ff", "#8338ec", "#ff006e", "#0ead69", "#fb5607"];
+
+function getUserName() {
+  const stored = localStorage.getItem('userName');
+  if (stored) return stored;
+  let name = '';
+  while (!name) {
+    name = prompt('Enter your name');
+    if (name === null) name = '';
+    name = name.trim();
+  }
+  localStorage.setItem('userName', name);
+  return name;
+}
+
+const userId = getUserName();
+document.getElementById('user-id').textContent = 'User: ' + userId;
 
 let fireworks;
 const popup = document.getElementById('win-popup');
@@ -398,17 +414,6 @@ function drawWheel() {
 loadConfig();
 
 // --- Spin logic ---
-function generateUserId() {
-  let id = '';
-  for (let i = 0; i < 16; i++) {
-    id += Math.floor(Math.random() * 10);
-  }
-  return id;
-}
-
-const userId = generateUserId();
-document.getElementById('user-id').textContent = 'User ID: ' + userId;
-
 const canvas = document.getElementById('wheel');
 const spinBtn = document.getElementById('spin');
 const resultEl = document.getElementById('result');

--- a/public/wheel.js
+++ b/public/wheel.js
@@ -1,6 +1,20 @@
 let config;
 let segments = [];
-const userId = 'demoUser';
+
+function getUserName() {
+  const stored = localStorage.getItem('userName');
+  if (stored) return stored;
+  let name = '';
+  while (!name) {
+    name = prompt('Enter your name');
+    if (name === null) name = '';
+    name = name.trim();
+  }
+  localStorage.setItem('userName', name);
+  return name;
+}
+
+const userId = getUserName();
 const balanceEl = document.getElementById('balance');
 const canvas = document.getElementById('wheel');
 const ctx = canvas.getContext('2d');
@@ -23,7 +37,7 @@ async function loadConfig() {
 }
 
 async function loadUser() {
-  const res = await fetch(`/api/users/${userId}`);
+  const res = await fetch(`/api/users/${encodeURIComponent(userId)}`);
   const data = await res.json();
   balanceEl.textContent = `Balance: ${data.points}`;
 }


### PR DESCRIPTION
## Summary
- prompt visitors for a username and store it locally
- use saved name for spins and leaderboard entries
- support name-based user loading in standalone wheel script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b91849a408832e896059c1d11ae1a5