### PR TITLE
Add registration and login with persistent user points

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -36,7 +36,8 @@ async function loadLogs() {
   logsTable.innerHTML = '';
   logs.forEach(l => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${l.userId}</td><td>${l.rewardType}</td><td>${l.timestamp}</td>`;
+    const name = l.userName || l.userId;
+    tr.innerHTML = `<td>${name}</td><td>${l.rewardType}</td><td>${l.timestamp}</td>`;
     logsTable.appendChild(tr);
   });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -321,21 +321,19 @@ let config;
 let segments = [];
 const colors = ["#ff9f1c", "#e71d36", "#2ec4b6", "#3a86ff", "#8338ec", "#ff006e", "#0ead69", "#fb5607"];
 
-function getUserName() {
-  const stored = localStorage.getItem('userName');
-  if (stored) return stored;
-  let name = '';
-  while (!name) {
-    name = prompt('Enter your name');
-    if (name === null) name = '';
-    name = name.trim();
+function getUser() {
+  const name = localStorage.getItem('userName');
+  const phone = localStorage.getItem('userPhone');
+  if (!name || !phone) {
+    window.location.href = 'login.html';
+    return { name: '', phone: '' };
   }
-  localStorage.setItem('userName', name);
-  return name;
+  return { name, phone };
 }
 
-const userId = getUserName();
-document.getElementById('user-id').textContent = 'User: ' + userId;
+const user = getUser();
+const userId = user.phone;
+document.getElementById('user-id').textContent = 'User: ' + user.name;
 
 let fireworks;
 const popup = document.getElementById('win-popup');
@@ -471,7 +469,7 @@ async function loadLeaderboard() {
     } else {
       board.forEach(row => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${row.userId}</td><td>${row.points}</td>`;
+        tr.innerHTML = `<td>${row.name}</td><td>${row.points}</td>`;
         tbody.appendChild(tr);
       });
     }

--- a/public/leaderboard.js
+++ b/public/leaderboard.js
@@ -5,7 +5,7 @@ async function loadBoard() {
   tbody.innerHTML = '';
   board.forEach(row => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${row.userId}</td><td>${row.points}</td>`;
+    tr.innerHTML = `<td>${row.name}</td><td>${row.points}</td>`;
     tbody.appendChild(tr);
   });
 }

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 400px; margin: 40px auto; }
+    form { margin-bottom: 24px; }
+    label { display:block; margin:8px 0 4px; }
+    input { width:100%; padding:8px; margin-bottom:8px; }
+    button { padding:8px 16px; }
+  </style>
+</head>
+<body>
+  <h1>Spin Wheel Login</h1>
+  <section>
+    <h2>Register</h2>
+    <form id="registerForm">
+      <label>Name<input type="text" id="regName" required></label>
+      <label>Phone<input type="text" id="regPhone" required></label>
+      <label>Password<input type="password" id="regPass" required></label>
+      <button type="submit">Register</button>
+    </form>
+  </section>
+  <section>
+    <h2>Login</h2>
+    <form id="loginForm">
+      <label>Phone<input type="text" id="logPhone" required></label>
+      <label>Password<input type="password" id="logPass" required></label>
+      <button type="submit">Login</button>
+    </form>
+  </section>
+  <script>
+    const regForm = document.getElementById('registerForm');
+    const loginForm = document.getElementById('loginForm');
+    regForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const body = {
+        name: document.getElementById('regName').value.trim(),
+        phone: document.getElementById('regPhone').value.trim(),
+        password: document.getElementById('regPass').value
+      };
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        alert('Registered successfully. Please login.');
+        regForm.reset();
+      } else {
+        alert(data.error || 'Registration failed');
+      }
+    });
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const body = {
+        phone: document.getElementById('logPhone').value.trim(),
+        password: document.getElementById('logPass').value
+      };
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        localStorage.setItem('userName', data.name);
+        localStorage.setItem('userPhone', data.phone);
+        window.location.href = 'index.html';
+      } else {
+        alert(data.error || 'Login failed');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/wheel.js
+++ b/public/wheel.js
@@ -1,20 +1,18 @@
 let config;
 let segments = [];
 
-function getUserName() {
-  const stored = localStorage.getItem('userName');
-  if (stored) return stored;
-  let name = '';
-  while (!name) {
-    name = prompt('Enter your name');
-    if (name === null) name = '';
-    name = name.trim();
+function getUser() {
+  const name = localStorage.getItem('userName');
+  const phone = localStorage.getItem('userPhone');
+  if (!name || !phone) {
+    window.location.href = 'login.html';
+    return { name: '', phone: '' };
   }
-  localStorage.setItem('userName', name);
-  return name;
+  return { name, phone };
 }
 
-const userId = getUserName();
+const user = getUser();
+const userId = user.phone;
 const balanceEl = document.getElementById('balance');
 const canvas = document.getElementById('wheel');
 const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- Add `/api/register` and `/api/login` endpoints storing users by phone with hashed passwords and accumulating points
- Record spins against authenticated users and expose usernames on leaderboard
- Introduce login page and update client scripts to require login

## Testing
- `npm install` *(fails: 403 Forbidden to registry)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b95e01a15c832eb35487e8dec6ae35