### PR TITLE
Add account page and show total points

### DIFF
--- a/public/account.html
+++ b/public/account.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Account</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; color: #333; }
+    ul { list-style: none; padding: 0; }
+    li { padding: 8px 0; border-bottom: 1px solid #ccc; }
+    button { margin-top: 16px; padding: 8px 16px; }
+  </style>
+</head>
+<body>
+  <h1>My Account</h1>
+  <p id="user-name"></p>
+  <p id="user-points"></p>
+  <h2>Reward History</h2>
+  <ul id="history"></ul>
+  <button id="backBtn">Back</button>
+  <script>
+    const name = localStorage.getItem('userName');
+    const phone = localStorage.getItem('userPhone');
+    if (!phone) {
+      window.location.href = 'login.html';
+    }
+    document.getElementById('user-name').textContent = 'User: ' + name;
+
+    async function loadAccount() {
+      try {
+        const userRes = await fetch(`/api/users/${phone}`);
+        const userData = await userRes.json();
+        document.getElementById('user-points').textContent = 'Total Points: ' + userData.points;
+        const res = await fetch(`/api/users/${phone}/logs`);
+        const logs = await res.json();
+        const history = document.getElementById('history');
+        if (logs.length === 0) {
+          const li = document.createElement('li');
+          li.textContent = 'No rewards yet';
+          history.appendChild(li);
+        } else {
+          logs.forEach(l => {
+            const li = document.createElement('li');
+            const date = new Date(l.timestamp).toLocaleString();
+            li.textContent = `${date} - ${l.rewardType}`;
+            history.appendChild(li);
+          });
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    loadAccount();
+    document.getElementById('backBtn').addEventListener('click', () => {
+      window.location.href = 'index.html';
+    });
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -284,6 +284,7 @@ button:focus {
       <h1>LUCKY WHEEL</h1>
       <p class="subtitle">Spin the wheel to win a prize!</p>
       <p id="user-id">User:</p>
+      <p id="user-points">Total Points: 0</p>
 
       <div id="wheel-wrapper">
         <div class="axle"></div>
@@ -295,6 +296,7 @@ button:focus {
       <button id="spin">Spin</button>
       <div id="result" aria-live="polite">Spin to win points!</div>
       <button id="leaderboardBtn">Show Leaderboard</button>
+      <button id="accountBtn">My Account</button>
       <button id="adminBtn">Admin Panel</button>
     </div>
     <div class="face back">
@@ -334,6 +336,21 @@ function getUser() {
 const user = getUser();
 const userId = user.phone;
 document.getElementById('user-id').textContent = 'User: ' + user.name;
+const userPointsEl = document.getElementById('user-points');
+let totalPoints = 0;
+
+async function loadUserPoints() {
+  try {
+    const res = await fetch(`/api/users/${userId}`);
+    const data = await res.json();
+    totalPoints = data.points;
+    userPointsEl.textContent = 'Total Points: ' + totalPoints;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+loadUserPoints();
 
 let fireworks;
 const popup = document.getElementById('win-popup');
@@ -440,11 +457,14 @@ spinBtn.addEventListener('click', () => {
       resultEl.textContent = `You won: ${seg.label}`;
       showPopup(seg.value);
       try {
-        await fetch('/api/logs', {
+        const res = await fetch('/api/logs', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ userId, rewardType: seg.label })
       });
+        const data = await res.json();
+        totalPoints = data.points;
+        userPointsEl.textContent = 'Total Points: ' + totalPoints;
     } catch (err) {
       console.error(err);
     }
@@ -454,6 +474,7 @@ spinBtn.addEventListener('click', () => {
 // --- Leaderboard flip ---
 const cardEl = document.getElementById('card');
 const leaderboardBtn = document.getElementById('leaderboardBtn');
+const accountBtn = document.getElementById('accountBtn');
 const backBtn = document.getElementById('backBtn');
 const tbody = document.querySelector('#board tbody');
 
@@ -492,6 +513,9 @@ backBtn.addEventListener('click', showWheel);
 const adminBtn = document.getElementById('adminBtn');
 adminBtn.addEventListener('click', () => {
   window.location.href = 'admin.html';
+});
+accountBtn.addEventListener('click', () => {
+  window.location.href = 'account.html';
 });
 </script>
 </body>

--- a/src/server.js
+++ b/src/server.js
@@ -91,6 +91,14 @@ app.get('/api/users/:phone', (req, res) => {
   res.json({ phone, name: user?.name || null, points: user?.points || 0 });
 });
 
+// User reward history
+app.get('/api/users/:phone/logs', (req, res) => {
+  const phone = req.params.phone;
+  const logs = readJSON(logsPath).filter(l => l.userId === phone);
+  const history = logs.map(l => ({ rewardType: l.rewardType, timestamp: l.timestamp }));
+  res.json(history);
+});
+
 // Leaderboard
 app.get('/api/leaderboard', (req, res) => {
   const users = readJSON(usersPath);


### PR DESCRIPTION
## Summary
- Display a player's total points above the wheel and keep it updated after spins.
- Introduce a My Account page that lists reward history and is accessible beside the leaderboard.
- Provide an API endpoint to retrieve a user's reward history.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b96426d5a8832ead936300ba932793