### PR TITLE
style: align account page with index theme

### DIFF
--- a/public/account.html
+++ b/public/account.html
@@ -5,19 +5,67 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Account</title>
   <style>
-    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; color: #333; }
-    ul { list-style: none; padding: 0; }
-    li { padding: 8px 0; border-bottom: 1px solid #ccc; }
-    button { margin-top: 16px; padding: 8px 16px; }
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #0d0d2b;
+      font-family: system-ui, sans-serif;
+      color: #fff;
+    }
+
+    #account-card {
+      background: #1b1b3a;
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+      width: 90%;
+      max-width: 420px;
+      text-align: center;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(1.5rem, 6vw, 2rem);
+      font-weight: 700;
+      background: linear-gradient(45deg,#ff7a00,#ffe600);
+      -webkit-background-clip: text;
+      color: transparent;
+      letter-spacing: 1px;
+    }
+
+    ul { list-style: none; padding: 0; margin: 16px 0 0; text-align: left; }
+    li { padding: 8px 0; border-bottom: 1px solid #444; }
+
+    button {
+      margin-top: 16px;
+      border: none;
+      border-radius: 9999px;
+      padding: 12px 24px;
+      font-size: 1rem;
+      background: #2980b9;
+      color: #fff;
+      cursor: pointer;
+      box-shadow: 0 4px 6px rgba(0,0,0,0.3);
+    }
+
+    button:hover { background: #3498db; }
+    button:focus { outline: 2px solid #fff; outline-offset: 2px; }
   </style>
 </head>
 <body>
-  <h1>My Account</h1>
-  <p id="user-name"></p>
-  <p id="user-points"></p>
-  <h2>Reward History</h2>
-  <ul id="history"></ul>
-  <button id="backBtn">Back</button>
+  <div id="account-card">
+    <h1>My Account</h1>
+    <p id="user-name"></p>
+    <p id="user-points"></p>
+    <h2>Reward History</h2>
+    <ul id="history"></ul>
+    <button id="backBtn">Back</button>
+  </div>
   <script>
     const name = localStorage.getItem('userName');
     const phone = localStorage.getItem('userPhone');


### PR DESCRIPTION
## Summary
- restyle account page to match dark, modern look of index page
- add card layout, gradient heading, and rounded buttons consistent with main theme

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b967528c28832e9e16ca21f74d2455