### PR TITLE
feat: load AdSense IDs from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,9 @@
+# .env.example
+
+# OpenAI key used by the backend
 OPENAI_API_KEY=
+
+# AdSense configuration (safe to publish)
+ADSENSE_CLIENT_ID=ca-pub-xxxxxxxxxxxxxxxx
+AD_SLOT_MOBILE_ID=1234567890
+AD_SLOT_DESKTOP_ID=0987654321

--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ Static pages for a 10‑segment spin wheel and admin panel live in `public/`.
 
 ### AdSense Configuration
 
-- Open `admin.html` and enter your **AdSense Client ID** and **ad unit IDs** under **AdSense Settings**.
-- The main `index.html` page reads these values from `localStorage`, so no ad keys are hard‑coded in the HTML.
+- Set the following in your `.env` file (see `.env.example`):
+  - `ADSENSE_CLIENT_ID`
+  - `AD_SLOT_MOBILE_ID`
+  - `AD_SLOT_DESKTOP_ID`
+- These IDs are exposed to the browser via `/env.js` and used by `app.js`.
+- You can still open `admin.html` to override them and store custom values in `localStorage`.
 
 ## Files
 ```

--- a/admin.html
+++ b/admin.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Admin – Wheel Settings & User Monitoring</title>
+<script src="/env.js"></script>
 <style>
 :root {
   --color-bg: #F4F6F8;
@@ -303,9 +304,13 @@ function updateToggleLabel() {
 }
 
 function loadAdsenseSettings() {
-  document.getElementById('adsenseClient').value = localStorage.getItem('adsenseClientId') || '';
-  document.getElementById('adsenseSlotMobile').value = localStorage.getItem('adSlotMobileId') || '';
-  document.getElementById('adsenseSlotDesktop').value = localStorage.getItem('adSlotDesktopId') || '';
+  const env = window.ENV || {};
+  document.getElementById('adsenseClient').value =
+    localStorage.getItem('adsenseClientId') || env.ADSENSE_CLIENT_ID || '';
+  document.getElementById('adsenseSlotMobile').value =
+    localStorage.getItem('adSlotMobileId') || env.AD_SLOT_MOBILE_ID || '';
+  document.getElementById('adsenseSlotDesktop').value =
+    localStorage.getItem('adSlotDesktopId') || env.AD_SLOT_DESKTOP_ID || '';
 }
 
 function saveAdSettings() {

--- a/app.js
+++ b/app.js
@@ -31,10 +31,11 @@ function initAdsense() {
   // Always ensure global array exists to avoid errors.
   window.adsbygoogle = window.adsbygoogle || [];
 
-  // Try manual configuration from localStorage (optional).
-  const client = localStorage.getItem('adsenseClientId');      // e.g., "ca-pub-xxxxxxxxxxxxxxxx"
-  const mobile = localStorage.getItem('adSlotMobileId');       // e.g., "1234567890"
-  const desktop = localStorage.getItem('adSlotDesktopId');     // e.g., "0987654321"
+  // IDs may come from the server-provided environment or localStorage overrides.
+  const env = window.ENV || {};
+  const client = env.ADSENSE_CLIENT_ID || localStorage.getItem('adsenseClientId');
+  const mobile = env.AD_SLOT_MOBILE_ID || localStorage.getItem('adSlotMobileId');
+  const desktop = env.AD_SLOT_DESKTOP_ID || localStorage.getItem('adSlotDesktopId');
 
   // If an AdSense client is provided, load the script (idempotent) and prepare footer slots.
   if (client) {

--- a/index.html
+++ b/index.html
@@ -5,14 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spin to Win</title>
 
-  <!-- Google AdSense Auto Ads (optional).
-       If you're using dynamic injection via localStorage (app.js), you can keep this or remove it.
-       Replace YOUR-ADSENSE-CLIENT-ID with your real client if using Auto Ads. -->
-  <script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=YOUR-ADSENSE-CLIENT-ID"
-    crossorigin="anonymous">
-  </script>
+  <!-- Google AdSense script is loaded dynamically in app.js using environment variables -->
+  <script src="/env.js"></script>
 
   <link rel="stylesheet" href="styles.css" />
 </head>
@@ -34,18 +28,12 @@
   </main>
 
   <div id="footer-ad">
-    <!-- Footer ad units. If you want static config, fill in data-ad-client and data-ad-slot.
-         If you store IDs in localStorage (adsenseClientId, adSlotMobileId, adSlotDesktopId),
-         app.js will set these automatically after consent. -->
+    <!-- Footer ad units. app.js fills data attributes using environment variables. -->
     <ins class="adsbygoogle mobile"
-         style="display:inline-block;width:320px;height:50px"
-         data-ad-client="YOUR-ADSENSE-CLIENT-ID"
-         data-ad-slot="YOUR-MOBILE-AD-UNIT-ID"></ins>
+         style="display:inline-block;width:320px;height:50px"></ins>
 
     <ins class="adsbygoogle desktop"
-         style="display:inline-block;width:728px;height:90px"
-         data-ad-client="YOUR-ADSENSE-CLIENT-ID"
-         data-ad-slot="YOUR-DESKTOP-AD-UNIT-ID"></ins>
+         style="display:inline-block;width:728px;height:90px"></ins>
   </div>
 
   <!-- Do NOT push ads here; consent flow in app.js handles loading/fill. -->

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import fs from 'fs';
@@ -40,6 +41,16 @@ app.use(cors());
 // Allow larger JSON bodies so base64-encoded logos can be saved
 app.use(express.json({ limit: '5mb' }));
 app.use(express.static(path.join(__dirname, '../public')));
+
+// Expose selected environment variables to the client
+app.get('/env.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`window.ENV=${JSON.stringify({
+    ADSENSE_CLIENT_ID: process.env.ADSENSE_CLIENT_ID || '',
+    AD_SLOT_MOBILE_ID: process.env.AD_SLOT_MOBILE_ID || '',
+    AD_SLOT_DESKTOP_ID: process.env.AD_SLOT_DESKTOP_ID || ''
+  })};`);
+});
 
 // Auth endpoints
 app.post('/api/register', (req, res) => {


### PR DESCRIPTION
## Summary
- expose AdSense client and slot IDs via `/env.js`
- use environment variables in client and admin pages
- document AdSense `.env` variables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b9d1bac0832e9ea4bee252661ad0