### PR TITLE
Track reward code availability and counts

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -35,7 +35,7 @@
     <div class="table-wrapper">
       <table id="redeem-table">
         <thead>
-          <tr><th>Name</th><th>Cost</th><th>Codes (comma separated)</th><th>Action</th></tr>
+          <tr><th>Name</th><th>Cost</th><th>Codes (code:amount, comma separated)</th><th>Available</th><th>Action</th></tr>
         </thead>
         <tbody></tbody>
       </table>


### PR DESCRIPTION
## Summary
- Add availability column to admin reward table and support code:amount input
- Compute availability on the fly and preserve redeemed counts when saving
- Update server to track code quantities and redemption counts

## Testing
- `npm test` (fails: Missing script: "test")
- `node --check src/server.js && echo 'server ok'`
- `node --check public/admin.js && echo 'admin ok'`
- `node --check public/redemption.js && echo 'redemption ok'`


------
https://chatgpt.com/codex/tasks/task_e_68bab267cad0832eac98e5f971d97b26