### PR TITLE
Allow multiple reward redemptions and display history

### DIFF
--- a/public/account.html
+++ b/public/account.html
@@ -70,7 +70,7 @@
     <h1>My Account</h1>
     <p id="user-name"></p>
     <p id="user-points"></p>
-    <h2>Reward History</h2>
+    <h2>Redemption History</h2>
     <ul id="history"></ul>
     <button id="backBtn">Back</button>
     <button id="logoutBtn">Logout</button>
@@ -88,18 +88,18 @@
         const userRes = await fetch(`/api/users/${phone}`);
         const userData = await userRes.json();
         document.getElementById('user-points').textContent = 'Total Points: ' + userData.points;
-        const res = await fetch(`/api/users/${phone}/logs`);
-        const logs = await res.json();
+        const res = await fetch(`/api/users/${phone}/redemptions`);
+        const redemptions = await res.json();
         const history = document.getElementById('history');
-        if (logs.length === 0) {
+        if (redemptions.length === 0) {
           const li = document.createElement('li');
-          li.textContent = 'No rewards yet';
+          li.textContent = 'No redemptions yet';
           history.appendChild(li);
         } else {
-          logs.forEach(l => {
+          redemptions.forEach(r => {
             const li = document.createElement('li');
-            const date = new Date(l.timestamp).toLocaleString();
-            li.textContent = `${date} - ${l.rewardType}`;
+            const date = new Date(r.timestamp).toLocaleString();
+            li.textContent = `${date} - ${r.rewardName}: ${r.code}`;
             history.appendChild(li);
           });
         }

--- a/public/redemption.js
+++ b/public/redemption.js
@@ -27,12 +27,8 @@ function renderRewards(rewards) {
     const div = document.createElement('div');
     div.className = 'reward';
     let html = `<strong>${r.name}</strong> - ${r.cost} pts`;
-    if (r.redeemedCode) {
-      html += `<p>Your code: ${r.redeemedCode}</p>`;
-    } else {
-      const disabled = r.available === 0 || userPoints < r.cost ? 'disabled' : '';
-      html += `<p>Available: ${r.available}</p><button data-id="${r.id}" ${disabled}>Redeem</button>`;
-    }
+    const disabled = r.available === 0 || userPoints < r.cost ? 'disabled' : '';
+    html += `<p>Available: ${r.available}</p><button data-id="${r.id}" ${disabled}>Redeem</button>`;
     div.innerHTML = html;
     rewardsEl.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- Allow users to redeem the same reward multiple times by tracking each code in an array
- Remove single-use check from reward listings and keep redeem button available
- Add redemption history endpoint and display previously redeemed codes on the account page

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc58f8a4f8832ebe8ec0fb0b7d800c