### PR TITLE
Ensure reward redemption waits for points to load

### DIFF
--- a/public/redemption.js
+++ b/public/redemption.js
@@ -40,6 +40,11 @@ async function loadRewards() {
   renderRewards(data);
 }
 
+async function refresh() {
+  await loadPoints();
+  await loadRewards();
+}
+
 rewardsEl.addEventListener('click', async e => {
   if (e.target.tagName === 'BUTTON') {
     const id = Number(e.target.getAttribute('data-id'));
@@ -51,8 +56,7 @@ rewardsEl.addEventListener('click', async e => {
     const data = await res.json();
     if (data.code) {
       alert('Your code: ' + data.code);
-      loadPoints();
-      loadRewards();
+      await refresh();
     } else if (data.error) {
       alert(data.error);
     }
@@ -62,6 +66,5 @@ rewardsEl.addEventListener('click', async e => {
 document.getElementById('backBtn').addEventListener('click', () => {
   window.location.href = 'index.html';
 });
+refresh();
 
-loadPoints();
-loadRewards();


### PR DESCRIPTION
## Summary
- Guarantee rewards render after points are fetched to avoid disabled buttons despite sufficient points
- Refresh points and rewards together after successful redemption

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5ba50820832eae705058e3d4d6b4