### PR TITLE
Add category selection to redemption flow

### DIFF
--- a/public/redemption.js
+++ b/public/redemption.js
@@ -28,7 +28,8 @@ function renderRewards(rewards) {
     div.className = 'reward';
     let html = `<strong>${r.name}</strong> - ${r.cost} pts`;
     const disabled = r.available === 0 || userPoints < r.cost ? 'disabled' : '';
-    html += `<p>Available: ${r.available}</p><button data-id="${r.id}" ${disabled}>Redeem</button>`;
+    const cats = JSON.stringify(r.categories || []);
+    html += `<p>Available: ${r.available}</p><button data-id="${r.id}" data-categories='${cats}' ${disabled}>Redeem</button>`;
     div.innerHTML = html;
     rewardsEl.appendChild(div);
   });
@@ -48,10 +49,12 @@ async function refresh() {
 rewardsEl.addEventListener('click', async e => {
   if (e.target.tagName === 'BUTTON') {
     const id = Number(e.target.getAttribute('data-id'));
+    const categories = JSON.parse(e.target.getAttribute('data-categories') || '[]');
+    const category = prompt('Choose category: ' + categories.join(', '));
     const res = await fetch('/api/redeem', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phone, rewardId: id })
+      body: JSON.stringify({ phone, rewardId: id, category })
     });
     const data = await res.json();
     if (data.code) {


### PR DESCRIPTION
## Summary
- include available code categories in reward listings
- prompt user to select a category before redeeming a reward
- ensure backend returns codes matching chosen category

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node src/server.js` *(fails: Cannot find package 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_68bc64d244dc832e89a9e2c9e53e8333